### PR TITLE
tweak language to make clear `exec "$@"` works

### DIFF
--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -179,7 +179,7 @@ A script that can contain simple commands to be run at runtime (as an
 `ENTRYPOINT <https://docs.docker.com/engine/reference/builder/#entrypoint>`_
 to the docker container). If you want this to be a shell script, make sure the
 first line is ``#!/bin/bash``. The last line must be ``exec "$@"``
-equivalent.
+or equivalent.
 
 Use this to set environment variables that software installed in your container
 expects to be set. This script is executed each time your binder is started and


### PR DESCRIPTION
originally it was: 

"The last line must be ``exec "$@"`` equivalent." 

Seemed open to interpretation that one needed to deduce what the equivalent of that would be here. I think adding 'or' before equivalent shows that will work. However, I assume other options exist and that is why the `equivalent` was there? Or why not have it read "The last line must be ``exec "$@"``"?

